### PR TITLE
Rename downloaded rubocop rules as main .rubocop.yml

### DIFF
--- a/recipes/configuration.rb
+++ b/recipes/configuration.rb
@@ -94,6 +94,9 @@ module Recipes
       inherit_from: https://raw.githubusercontent.com/MarsBased/marstyle/master/ruby/.rubocop.yml
       CODE
       end
+      @template.run 'rubocop public'
+      @template.remove_file '.rubocop.yml'
+      @template.run 'mv .rubocop-https---raw-githubusercontent-com-MarsBased-marstyle-master-ruby--rubocop-yml .rubocop.yml'
     end
 
   end


### PR DESCRIPTION
Closes #42 