### PR TITLE
Avoid devise initializer conflict

### DIFF
--- a/recipes/devise.rb
+++ b/recipes/devise.rb
@@ -8,6 +8,7 @@ module Recipes
     end
 
     def cook
+      avoid_devise_conflict if previous_devise_config?
       @template.generate 'devise:install'
       add_development_env_config
       add_route_config
@@ -35,6 +36,14 @@ module Recipes
         \s\send
       RUBY
       end
+    end
+
+    def avoid_devise_conflict
+      @template.remove_file 'config/initializers/devise.rb'
+    end
+
+    def previous_devise_config?
+      @pathfinder.recipes_list.map(&:class).include?(Recipes::ActiveAdmin)
     end
 
   end


### PR DESCRIPTION
ActiveAdmin installs Devise (AdminUser) causing a devise.rb initializer conflict when app tries to install Devise (with User). The file is the same but it conflicts because have different key.

To avoid this, we check if we installed ActiveAdmin and remove the old initializer file before Devise installation.